### PR TITLE
libdrm: Added cairo as dependency

### DIFF
--- a/Formula/libdrm.rb
+++ b/Formula/libdrm.rb
@@ -16,6 +16,7 @@ class Libdrm < Formula
 
   depends_on "docutils" => :build
   depends_on "meson" => :build
+  depends_on "cairo" => :build
   depends_on "ninja" => :build
   depends_on "pkg-config" => :build
   depends_on "libpciaccess"


### PR DESCRIPTION
Building libdrm failed because of missing cairo.h:

```
tests/util/libutil.a.p/pattern.c.o.d -o tests/util/libutil.a.p/pattern.c.o -c ../tests/util/pattern.c
../tests/util/pattern.c:34:10: fatal error: cairo.h: No such file or directory
   34 | #include <cairo.h>
      |          ^~~~~~~~~
compilation terminated.
```

After adding cairo as dependency, everything works as expected.
